### PR TITLE
feat: add a listener for reward redemptions

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,6 +61,15 @@ bot.loop.run_until_complete(bot.__ainit__())
 async def event_eventsub_notification_channel_shoutout_receive(payload: eventsub.ChannelShoutoutReceiveData) -> None:
     logger.info(f"{datetime.datetime.now().isoformat()}, Shoutout Event, {payload.data.user.name}")
 
+
+@esbot.event()
+async def event_eventsub_notification_channel_reward_redeem(
+    payload: eventsub.CustomReward,
+) -> None:
+    logger.info(
+        f"{payload.data.redeemed_at}, Redeem Event, {payload.data.id}, {payload.data.broadcaster.name}, {payload.data.user.name}, {payload.data.reward.title}, {payload.data.status}"
+     )  
+
 @esbot.event()
 async def event_eventsub_notification_followV2(payload: eventsub.ChannelFollowData) -> None:
     logger.info(f"{payload.data.followed_at}, Follow Event, {payload.data.user.name}, {payload.data.broadcaster.name}") #this uses the payload timestamp instead


### PR DESCRIPTION
I heard you like redemption events

```
DEBUG:twitchio.ext.eventsub:Recived a message type: notification
DEBUG:twitchio.client:dispatching event eventsub_notification_channel_reward_redeem
INFO:aiohttp.access:127.0.0.1 [27/May/2023:03:37:10 +0000] "POST /callback HTTP/1.0" 200 149 "-" "twitch-cli/1.1.19"
INFO:twitchio.http:Something something

```
So our main first problem was that we did not read the docs and just made shit up.

If you want to develop this API stuff there is no way around having a way to simulate the events that you need. Without this I would not be able to figure this out. There's no way around not having and using the 'twitch cli' ( https://dev.twitch.tv/docs/cli/configure-command/ )

```bash
twitch event trigger channel.channel_points_custom_reward_redemption.add --version 1 -s <WEBHOOK_SECRET> --forward-address https://<CALLBACK_URL>
```

Then look up the type of event you want to trigger from this list: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/

> 'How do I find this?' You may ask. With logging at DEBUG every '200' will show up with something that you can search for. Then search the twitchio git repo, the pythonista discord and then google for whatever you may find.

You can find out what you can subscribe to here: https://twitchio.dev/en/latest/exts/eventsub.html#twitchio.ext.eventsub.EventSubClient.subscribe_channel_points_redeem_updated AND this will also tell you what scopes you need.. turns out we needed:

> Must have channel:read:redemptions or channel:manage:redemptions scope.

The next thing you need is an event listener which will do something for you when an event is triggered.

When you try the `twitch event trigger ` command you will get some json back, either save it as a file and use the vscode formatter (CTRL+SHIFT+I) or run it through `jq`

that will make it easier to see what you are looking for

It should look like this:
```json

{
  "subscription": {
    "id": "d86f1459-a2af-41d0-ae2a-3fee5a60402e",
    "status": "enabled",
    "type": "channel.channel_points_custom_reward_redemption.add",
    "version": "1",
    "condition": {
      "broadcaster_user_id": "5016229"
    },
    "transport": {
      "method": "webhook",
      "callback": "null"
    },
    "created_at": "2023-05-27T04:22:01.647018895Z",
    "cost": 0
  },
  "event": {
    "id": "d86f1459-a2af-41d0-ae2a-3fee5a60402e",
    "broadcaster_user_id": "5016229",
    "broadcaster_user_login": "testBroadcaster",
    "broadcaster_user_name": "testBroadcaster",
    "user_id": "893426129",
    "user_login": "testFromUser",
    "user_name": "testFromUser",
    "user_input": "Test Input From CLI",
    "status": "unfulfilled",
    "reward": {
      "id": "380c9a9f-1031-bed6-e717-94e16b1f6e05",
      "title": "Test Reward from CLI",
      "cost": 150,
      "prompt": "Redeem Your Test Reward from CLI"
    },
    "redeemed_at": "2023-05-27T04:22:01.647018895Z"
  }
}

```

The last thing we need is a way to find out how our function signature* has to look from looking at the docs. I take the event that I know works and search that in the twitchio codebase, then transfer from the 'follows' thing to a 'redeem' thing

```python
@esbot.event()
async def event_eventsub_notification_channel_reward_redeem(
    payload: eventsub.CustomReward,
) -> None:
    logger.info(
        f"{payload.data.redeemed_at}, Redeem Event, {payload.data.id}, {payload.data.broadcaster.name}, {payload.data.user.name}, {payload.data.reward.title}, {payload.data.status}"
     )
```

What does it do?
We start with `@esbot.event()` this tells us that it is an event that somehow belongs to our eventsub-bot (esbot)

Whenever our esbot sees a `eventsub.CustomReward`-event it will do stuff for us. In this case it will print a timestamp, a string, a unique id for this specific event, a broadcaster name, a user name, a reward title and a status (fullfilled/unfullfilled)

Note the name of this function '*event_eventsub_notification_channel_reward_redeem*' is important because it comes from the library. It has to be correct. You cannot do something like:
```python
@esbot.event()
async def fucking_great(
    payload: eventsub.CustomReward,
) -> None:
    logger.info(
        f"{payload.data.redeemed_at}, Redeem Event, {payload.data.id}, {payload.data.broadcaster.name}, {payload.data.user.name}, {payload.data.reward.title}, {payload.data.status}"
     )
```

\* what's a 'function signature'? The name of a function, what arguments go into it and whatever will it return*

Read:
```python
async def event_eventsub_notification_channel_reward_redeem(
    payload: eventsub.CustomReward,
) -> None:
```
In words:
An asynchronous function with the name `event_eventsub_notification_channel_reward_redeem` that takes a variable named `payload` of the type `eventsub.CustomReward` and returns an object of type `None`. You can take `payload` do whatever you want and return nothing. Great!